### PR TITLE
Add unit tests

### DIFF
--- a/test/bookmark_notifier_test.dart
+++ b/test/bookmark_notifier_test.dart
@@ -1,0 +1,59 @@
+import 'dart:io';
+
+import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hive/hive.dart';
+
+import 'package:cine_nest/boxes/boxes.dart';
+import 'package:cine_nest/models/bookmark_model.dart';
+import 'package:cine_nest/providers/bookmark_provider.dart';
+
+void main() {
+  late Directory tempDir;
+
+  setUp(() async {
+    tempDir = await Directory.systemTemp.createTemp('hive_test');
+    Hive.init(tempDir.path);
+    Hive.registerAdapter(BookmarkModelAdapter());
+    await Boxes.openBookmarkBox();
+  });
+
+  tearDown(() async {
+    await Hive.deleteBoxFromDisk('BookmarkBox');
+    await tempDir.delete(recursive: true);
+  });
+
+  test('updateBookmarks stores bookmarks and updates state', () async {
+    final container = ProviderContainer();
+    addTearDown(container.dispose);
+    final notifier = container.read(bookmarkProvider.notifier);
+
+    final bookmarks = [
+      BookmarkModel(movieId: '1', createdOn: DateTime.now()),
+      BookmarkModel(movieId: '2', createdOn: DateTime.now()),
+    ];
+
+    await notifier.updateBookmarks(bookmarks);
+
+    final boxBookmarks = Boxes.getBookmarks().values.toList();
+    expect(boxBookmarks.length, 2);
+    expect(notifier.state.length, 2);
+  });
+
+  test('clear removes all bookmarks from box and state', () async {
+    final container = ProviderContainer();
+    addTearDown(container.dispose);
+    final notifier = container.read(bookmarkProvider.notifier);
+
+    await notifier.updateBookmarks([
+      BookmarkModel(movieId: '1', createdOn: DateTime.now()),
+    ]);
+
+    expect(notifier.state.isNotEmpty, true);
+
+    await notifier.clear();
+
+    expect(Boxes.getBookmarks().isEmpty, true);
+    expect(notifier.state.isEmpty, true);
+  });
+}

--- a/test/movie_model_test.dart
+++ b/test/movie_model_test.dart
@@ -1,0 +1,28 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:cine_nest/models/movie_model.dart';
+
+void main() {
+  test('fromJson parses optional fields correctly', () {
+    final json = {
+      'id': 'tt1',
+      'title': 'Test',
+      'year': '2021',
+      'genres': ['Drama'],
+      'ratings': [1, 2],
+      'posterurl': 'url',
+      'contentRating': '',
+      'duration': '',
+      'releaseDate': '2021-01-01',
+      'originalTitle': '',
+      'storyline': 'Story',
+      'actors': ['A'],
+      'imdbRating': ''
+    };
+
+    final model = MovieModel.fromJson(json);
+    expect(model.contentRating, isNull);
+    expect(model.duration, isNull);
+    expect(model.imdbRating, isNull);
+    expect(model.genres, contains('Drama'));
+  });
+}

--- a/test/validators_test.dart
+++ b/test/validators_test.dart
@@ -1,0 +1,52 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:cine_nest/utils/validators.dart';
+
+void main() {
+  group('validateEmail', () {
+    test('returns error for null or empty', () {
+      expect(Validators.validateEmail(null), isNotNull);
+      expect(Validators.validateEmail(''), isNotNull);
+    });
+
+    test('returns error for invalid email', () {
+      expect(Validators.validateEmail('invalid'), isNotNull);
+      expect(Validators.validateEmail('test@'), isNotNull);
+    });
+
+    test('returns null for valid email', () {
+      expect(Validators.validateEmail('user@example.com'), isNull);
+    });
+  });
+
+  group('validatePassword', () {
+    test('returns error for empty password', () {
+      expect(Validators.validatePassword(''), isNotNull);
+    });
+
+    test('returns error for short password', () {
+      expect(Validators.validatePassword('12345'), isNotNull);
+    });
+
+    test('returns null for valid password', () {
+      expect(Validators.validatePassword('secret123'), isNull);
+    });
+  });
+
+  group('validateNickname', () {
+    test('returns error for empty nickname', () {
+      expect(Validators.validateNickname(''), isNotNull);
+    });
+
+    test('returns error for too short nickname', () {
+      expect(Validators.validateNickname('ab'), isNotNull);
+    });
+
+    test('returns error for too long nickname', () {
+      expect(Validators.validateNickname('a' * 17), isNotNull);
+    });
+
+    test('returns null for valid nickname', () {
+      expect(Validators.validateNickname('FlutterDev'), isNull);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- add tests for validator helpers
- add provider test for bookmark notifier
- test movie model JSON parsing

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685bee2d4614832892dc099b8008df7e